### PR TITLE
Review test coverage

### DIFF
--- a/src/lambda_handler.py
+++ b/src/lambda_handler.py
@@ -54,7 +54,6 @@ def lambda_handler(event, context):
 
             logger.info(f'Getting last timestamp for {table_name} table.')
             last_timestamp = get_timestamp(table_name)
-            last_timestamp = datetime.strptime(last_timestamp, '%Y-%m-%d_%H-%M')
             logger.info(f'Last timestamp for {table_name} table ({last_timestamp}) has been retrieved')
 
             logger.info(f'Getting newest table data from {table_name} table.')

--- a/src/util_functions/get_timestamp.py
+++ b/src/util_functions/get_timestamp.py
@@ -1,8 +1,10 @@
 import boto3
 import pandas as pd
+from datetime import datetime
 from io import StringIO
 from botocore.exceptions import ClientError
 from src.util_functions.setup_logger import setup_logger  # Change path when lambda is ready
+
 
 logger = setup_logger("extraction")
 
@@ -26,8 +28,10 @@ def get_timestamp(table_name: str) -> str:
         timestamp_df = pd.read_csv(StringIO(response.read().decode("utf-8")))
         timestamp = timestamp_df["Date"].max()
         if not timestamp:
-            return "0001-01-01_01-01"
-
+            timestamp = "0001-01-01_01-01"
+        timestamp = datetime.strptime(timestamp, '%Y-%m-%d_%H-%M')
+        print(timestamp)
+        print(type(timestamp))
         logger.info(
             "Retrieved get_timestamp.",
             extra={"table_name": table_name, "bucket_name": bucket_name},
@@ -41,7 +45,7 @@ def get_timestamp(table_name: str) -> str:
                 f"No timestamps file found for table '{table_name}'. This might be the first run.",
                 extra={"table_name": table_name, "bucket_name": bucket_name},
             )
-            return "0001-01-01_01-01"
+            return datetime.strptime("0001-01-01_01-01", '%Y-%m-%d_%H-%M')
         else:
             logger.error(
                 f"An AWS related error occurred: {e}",

--- a/src/util_functions/upload_to_s3_util_func.py
+++ b/src/util_functions/upload_to_s3_util_func.py
@@ -38,7 +38,6 @@ def upload_tables_to_s3(
         f"Timestamp generated for the upload: {timestamp_str}",
         extra={"table_name": table_name, "bucket_name": bucket_name},
     )
-    save_timestamps(table_name, timestamp_str, bucket_name)
     # create a var for the file key in
     # "[Table Name]/Year/Month/Day/hh-mm/[tablename]-[timestamp].csv"
 
@@ -79,10 +78,12 @@ def upload_tables_to_s3(
                     "s3_key": f"{s3_key}",
                 },
             )
+            save_timestamps(table_name, timestamp_str, bucket_name)
             return (
                 f"Table {table_name} has been uploaded to "
                 + f"{bucket_name} with key {s3_key}."
             )
+        save_timestamps(table_name, timestamp_str, bucket_name)
         return("No new data to upload")
 
     except ClientError as e:

--- a/test/test_util_functions/test_get_timestamp.py
+++ b/test/test_util_functions/test_get_timestamp.py
@@ -1,5 +1,6 @@
 from src.util_functions.get_timestamp import get_timestamp as gt
 from botocore.exceptions import ClientError
+from datetime import datetime
 import pytest
 from moto import mock_aws
 import os
@@ -21,7 +22,7 @@ def s3_client(aws_creds):
     with mock_aws():
         s3_client = boto3.client("s3")
         s3_client.create_bucket(
-            Bucket="test_bucket",
+            Bucket="smith-morra-ingestion-bucket",
             CreateBucketConfiguration={
                 "LocationConstraint": "eu-west-2",
             },
@@ -29,20 +30,20 @@ def s3_client(aws_creds):
         yield s3_client
 
 
-@pytest.mark.it("Test returns timestamp string")
+@pytest.mark.it("Test returns datetime timestamp")
 def test_returns_string(s3_client):
     table_name = "test_table"
     with open("test/test_timestamps.csv", "r", encoding="utf-8") as f:
         s3_client.put_object(
-            Bucket="test_bucket", Key=f"{table_name}/timestamps.csv", Body=f.read()
+            Bucket="smith-morra-ingestion-bucket", Key=f"{table_name}/timestamps.csv", Body=f.read()
         )
-    assert gt(table_name) == "2024-08-14_14-09"
+    assert gt(table_name) == datetime(2024, 8, 14, 14, 9)
 
 
 @pytest.mark.it("Returns 0 AD if no timestamps")
 def test_no_timestamps(s3_client):
     table_name = "test_table"
-    assert gt(table_name) == "0001-01-01_01-01"
+    assert gt(table_name) == datetime(1, 1, 1, 1, 1)
 
 
 @pytest.mark.it("Test ClientError handling")


### PR DESCRIPTION
Pull request includes a couple of refactors:
- save_timestamp is only invoked after the tables have been successfully saved
- get_timestamp now returns a datetime object (get_table expects to be passed one of these)

Added a new test to upload_to_s3 looking at the ClientError handling.
